### PR TITLE
JWT typo fixed

### DIFF
--- a/.env.bak
+++ b/.env.bak
@@ -4,7 +4,7 @@ API_ENVIRONMENT=dev
 API_FRONTEND_URL=http://localhost:8081
 
 # JWT
-JWT_SECRECT=
+JWT_SECRET=
 
 # HOST
 DOMAIN=sheileyshopapi.app.test


### PR DESCRIPTION
The .env.bak file has a typo in the JWT_SECRET var. 

With this PR it will resolved.